### PR TITLE
plate2kml.py

### DIFF
--- a/src/vw/Plate/Makefile.am
+++ b/src/vw/Plate/Makefile.am
@@ -149,6 +149,9 @@ plate2dem_LDADD   = @PKG_CARTOGRAPHY_LIBS@ $(PLATE_LOCAL_LIBS)
 plate2kml_SOURCES = plate2kml.cc
 plate2kml_LDADD   = $(PLATE_LOCAL_LIBS) 
 
+tiles4region_SOURCES = tiles4region.cc
+tiles4region_LDADD   = $(PLATE_LOCAL_LIBS) 
+
 index_client_SOURCES = index_client.cc
 index_client_LDADD = $(PLATE_LOCAL_LIBS)
 
@@ -184,7 +187,8 @@ bin_PROGRAMS =   \
   rebuild_index  \
   rpc_tool       \
   snapshot       \
-  tiles2plate
+  tiles2plate    \
+  tiles4region
 
 if HAVE_PKG_LIBKML
   bin_PROGRAMS += plate2kml

--- a/src/vw/Plate/plate2kml.py
+++ b/src/vw/Plate/plate2kml.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python2.7
+import optparse
+import sys, os, time
+import math
+sys.path.insert(1, '/Users/ted/local/src/libkml-1.2.0/build/lib/python2.7/site-packages') # tmo
+import kmldom
+import kmlengine
+import subprocess
+import json
+import zipfile
+import urlparse
+import multiprocessing
+import threading
+import Queue # this is just imported for the Queue.Empty exception <shrug>
+
+
+TILE_MIN_LOD, TILE_MAX_LOD = (64, 513)
+HARD_CODED_TILE_SIZE = 256
+
+DEFAULT_MAX_KMZ_FEATURES = 256
+DEFAULT_DRAW_ORDER_FACTOR = 10 # presently hardcoded: tiles will be rendererd at DRAW_ORDER_FACTOR * tile_level
+DEFAULT_VW_BIN_PATH = '/Users/ted/local/bin/'
+DEFAULT_REGIONATION_OFFSET = 5
+DEFAULT_WORKERS = 6
+
+def int_or_none(val):
+    try:
+        return int(val)
+    except TypeError:
+        return None
+
+class BBox(object):
+    """
+    >>> boxa = BBox(0,0,4,4)
+    >>> boxa.minx, boxa.miny, boxa.maxx, boxa.maxy, boxa.width, boxa.height
+    (0, 0, 3, 3, 4, 4)
+    
+    >>> boxb = BBox(1,1,1,1)
+    >>> boxb.minx, boxb.miny, boxb.maxx, boxb.maxy, boxb.width, boxb.height
+    (1, 1, 1, 1, 1, 1)
+
+    >>> boxa.contains(boxb)
+    True
+    >>> boxb.contains(boxa)
+    False
+    >>> boxb.is_null()
+    False
+    >>> BBox().is_null()
+    True
+    >>> bb = BBox()
+    >>> bb.expand(0,0)
+    >>> bb.is_null()
+    False
+
+    >>> boxa.expand(16,16)
+    >>> boxa.expand(-16,-16)
+    >>> boxa.minx, boxa.miny, boxa.maxx, boxa.maxy, boxa.width, boxa.height
+    (-16, -16, 16, 16, 33, 33)
+    >>> [b.corners for b in boxa.quarter()]
+    [((-16, -16), (-1, -1)), ((-16, 0), (-1, 15)), ((0, -16), (15, -1)), ((0, 0), (15, 15))]
+    
+    
+    """
+    class BBoxTypeError(Exception):
+        """Raise if a method is called that doesn't make sense for this kind of BBox"""
+        pass
+
+    def __init__(self, minx=None, miny=None, width=None, height=None, maxx=None, maxy=None, discrete=True):
+        initprops =  ('minx','miny','maxx','maxy')
+        args = locals()
+        self.discrete = discrete
+        if all( args[prop] == None for prop in  ('minx','miny','maxx','maxy','width','height') ):
+            # init props are null.  initialize an empty bounding box
+            for prop in initprops:
+                setattr(self, prop, None)
+        else:
+            if (minx == None) or (miny == None):
+                raise ValueError("Required: minimum x and y values")
+            if not bool(width and height) ^ bool(maxx and maxy):
+                raise ValueError("You must provide either width & height or maximum x & y values (not both)")
+
+            if width != None or height != None:
+                assert width != None and height != None and minx != None and miny != None
+                assert (not maxx and not maxy)
+                if not self.discrete:
+                    raise BBoxTypeError("Width and height only make sense for discrete BBoxes")
+                maxx = minx + width - 1
+                maxy = miny + height - 1
+
+            if self.discrete:
+                for prop in initprops:
+                    setattr(self, prop, int_or_none(locals()[prop]))
+            else:
+                for prop in initprops:
+                    setattr(self, prop, locals()[prop])
+    @property
+    def width(self):
+        if  self.discrete:
+            return self.maxx - self.minx + 1
+        else:
+            return abs(self.maxx - self.minx)
+
+    @property
+    def height(self):
+        if self.discrete:
+            return self.maxy - self.miny + 1
+        else:
+            return abs(self.maxy - self.miny)
+
+    def is_null(self):
+        if any( getattr(self,p) == None for p in ('minx','miny','maxx','maxy') ):
+            assert all( getattr(self,p) == None for p in ('minx','miny','maxx','maxy') )
+            return True
+        else:
+            return False
+
+    @property
+    def corners(self):
+        return ( (self.minx, self.miny), (self.maxx, self.maxy ))
+
+    def contains(self, bbox):
+        """
+        Check whether the given bounding box is inside this one and return a boolean.
+        """
+        b1 = self.corners
+        b2 = bbox.corners
+        return b1[0][0] <= b2[0][0] and\
+        b1[0][1] <= b2[0][1] and\
+        b1[1][0] >= b2[1][0] and\
+        b1[1][1] >= b2[1][1]
+
+    def expand(self, x,y):
+        """
+        Expand the bounding box if the coordinates lie outside its bounds.
+        If the given coordinates lie outside the bounds of the BBox, 
+        expand the BBox to cover them.
+        """
+        if (self.minx == None) or (x < self.minx):
+            self.minx = x
+        if (self.maxx == None) or (x > self.maxx):
+            self.maxx = x
+        if (self.miny == None) or (y < self.miny):
+            self.miny = y
+        if (self.maxy == None) or (y > self.maxy):
+            self.maxy = y
+
+
+
+    def quarter(self):
+        """(generator) Break out into 4 subregions, if possible"""
+        if self.width == 1 and self.height == 1:
+            yield self
+            raise StopIteration
+        elif self.width == 1 or self.height == 1 or self.width != self.height:
+            # This assumption simplifies matters greatly
+            raise NotImplementedError
+        else:
+            for x in (self.minx, self.minx + self.width / 2):
+                for y in (self.miny, self.miny + self.height / 2):
+                    yield BBox(x, y, self.width/2, self.height/2)
+        
+
+class TileRegion(object):
+    def __init__(self, level, bbox):
+        self.level = level
+        if callable(bbox):
+            self._bbox = bbox()
+        else:
+            self._bbox = bbox
+        self.latlon_bbox = BBox(discrete=False) # initially empty, this decouples the region's degree-space bounds from it's tile-space bounds.
+        self.tile_degree_size = None
+
+    @property
+    def minx(self):
+        return self._bbox.minx
+    @property
+    def miny(self):
+        return self._bbox.miny
+    @property
+    def maxx(self):
+        return self._bbox.minx
+    @property
+    def maxy(self):
+        return self._bbox.miny
+    @property
+    def width(self):
+        return self._bbox.width
+    @property
+    def height(self):
+        return self._bbox.height
+
+    def name(self):
+        return "L%02dR%dC%dW%dH%d" % (self.level, self.miny, self.minx, self.width, self.height)
+
+    @property
+    def kmz_filename(self):
+        return self.name()+".kmz"
+
+    def __hash__(self):
+        return (self.level, self.minx, self.bbox.miny, self.bbox.width, self.bbox.height).__hash__()
+
+    def tiles(self):
+        """
+        Iterate over the tiles contained by this region.
+        Some of these may not be in the plate file.
+        If you want to iterate over tiles actually in the plate, use search_tiles_by_region.
+        """
+        c = self.minx
+        r = self.miny
+        for i in range(self.width):
+            for j in range(self.height):
+                yield Tile(r+j, c+i, self.level)
+
+    def subdivide(self):
+        """
+        Quarter this region.
+        """
+        for bbox in self.bbox.quarter():
+            subregion = self.TileRegion(self.level, bbox)
+            yield subregion
+
+    def project_to_level(self, level):
+        """
+        Return a TileRegion representing the extent of this TileRegion,
+        projected onto a different level of the tile pyramid.
+        """
+        
+        level_delta = level - self.level
+        if level_delta == 0:
+            return self
+        scale_factor = 2 ** level_delta
+        proj_bbox = BBox(
+            self.minx * scale_factor,
+            self.miny * scale_factor,
+            self.width * scale_factor,
+            self.height * scale_factor
+        )
+        if level_delta < 0:
+            # Ensure that region bounds are still integers
+            for prop in (proj_bbox.minx, proj_bbox.miny, proj_bbox.width, proj_bbox.height):
+                assert prop % 1 == 0
+
+        return TileRegion( level, proj_bbox )
+
+    def kml_region(self):
+        region = factory.CreateRegion()
+        
+        if self.level == 1:
+          ## Top layerish. Layer 0 is never drawn because it's
+          ## boundaries are illegal (Lat range too large). So this step
+          ## is to make sure layer 1 can always be seen when zoomed out.
+            #minlod, maxlod = (1,513)
+            minlod, maxlod = (1,1024)
+        else:
+            degree_width = abs(self.latlon_bbox.maxx - self.latlon_bbox.minx)
+            degree_height = abs(self.latlon_bbox.maxy - self.latlon_bbox.miny)
+            region_degree_size = math.sqrt(degree_width * degree_height)
+            minlod = int(TILE_MIN_LOD / self.tile_degree_size * region_degree_size)
+            maxlod = int(math.ceil(TILE_MAX_LOD / self.tile_degree_size * region_degree_size))
+
+
+            # It isn't awesome that this relies on the command-line options to know when it's at the deepest level.
+            # Perhaps there is a way to get this information from the Plate directly?
+            if self.level == options.max_levels:
+                maxlod = -1
+
+        region.set_lod(create_lod(minlod, maxlod, factory))
+        
+        assert not self.latlon_bbox.is_null() # presumably, we already added some points to the latlon_bbox with latlon_bbox.expand()
+        latlonalt_box = create_latlonalt_square(self.latlon_bbox.maxy, self.latlon_bbox.miny, self.latlon_bbox.minx, self.latlon_bbox.maxx, factory)
+        region.set_latlonaltbox(latlonalt_box)
+        return region
+
+class Tile(object):
+    def __init__(self, row, col, level, west=None, east=None, north=None, south=None, filetype="png"):
+        self.row = row
+        self.col = col
+        self.level = level
+        self.west = west
+        self.east = east
+        self.north = north
+        self.south = south
+        self.filetype = filetype
+        self.pixel_width = HARD_CODED_TILE_SIZE
+        self.pixel_height = HARD_CODED_TILE_SIZE
+
+    @property
+    def degree_width(self):
+        return abs(self.east - self.west)
+    @property
+    def degree_height(self):
+        return abs(self.north - self.south)
+
+    def latlonbox(self):
+        """
+        lon_delta = 360.0 / (2**self.level)
+        lat_delta = 180.0 / (2**self.level)
+        west = -180 + self.col * lon_delta
+        east = west + lon_delta
+        north = 90 - lat_delta * self.row
+        south = north - lat_delta
+        """
+
+        llbox = factory.CreateLatLonBox()
+        llbox.set_west(self.west)
+        llbox.set_south(self.south)
+        llbox.set_east(self.east)
+        llbox.set_north(self.north)
+        return llbox
+
+    def bbox(self):
+        return BBox(
+            self.col,
+            self.row,
+            1,
+            1
+        )    
+
+    def kml_region(self, factory):
+        region = factory.CreateRegion()
+        
+        if self.level == 1:
+          ## Top layerish. Layer 0 is never drawn because it's
+          ## boundaries are illegal (Lat range too large). So this step
+          ## is to make sure layer 1 can always be seen when zoomed out.
+            #minlod, maxlod = (1,513)
+            minlod, maxlod = (1,1024)
+        else:
+            minlod, maxlod = (TILE_MIN_LOD, TILE_MAX_LOD)
+
+            # Again, not awesome.  See comment for Tile's kml_region()
+            if self.level == options.max_levels:
+                maxlod = -1
+
+        region.set_lod(create_lod(minlod, maxlod, factory))
+        
+        latlonalt_box = create_latlonalt_square(self.north, self.south, self.west, self.east, factory)
+        region.set_latlonaltbox(latlonalt_box)
+        return region
+
+
+    def kml_overlay(self, factory):
+        goverlay = factory.CreateGroundOverlay()
+        region = self.kml_region(factory)
+        goverlay.set_region(region)
+        goverlay.set_latlonbox(self.latlonbox())
+        goverlay.set_draworder(self.level * DEFAULT_DRAW_ORDER_FACTOR) 
+
+        url = urlparse.urljoin( options.baseurl, '/'.join( str(t) for t in (self.level, self.col, self.row) ) + "."+self.filetype )
+        icon = factory.CreateIcon()
+        icon.set_href( str(url) )
+        goverlay.set_icon( icon )
+
+        return goverlay
+        
+class PlateLevel(object): 
+    def __init__(self, level):
+        self.level = level
+        self.region = TileRegion(level, BBox(0,0,2**level,2**level))
+
+    def regionate(self, offset=-9999, restrict_to_regions=[]):
+        """
+        Generate regions for this plate level, based on some heuristics.
+        If a list of restrict_to_regions is given, only produce regions contained by those regions.
+        """
+        if offset == -9999:
+            offset = options.regionation_offset
+        region_level = self.level - offset
+
+        if region_level <= 0:
+            yield self.region
+        else:
+
+            if restrict_to_regions:
+                for reg in restrict_to_regions:
+                    reg = reg.project_to_level(region_level)
+                    for tile in reg.tiles():
+                        yield TileRegion(region_level, tile.bbox).project_to_level(self.level)
+            else:
+                offset_region = TileRegion(region_level, BBox(
+                    0,
+                    0,
+                    2**region_level,
+                    2**region_level
+                ))
+                for tile in offset_region.tiles():
+                    yield TileRegion(region_level, tile.bbox).project_to_level(self.level)
+
+class PlateException(Exception):
+    pass
+class PlateDepthExceededException(PlateException):
+    pass
+
+def search_tiles_by_region(platefile_url, region):
+    args = '%d %d %d %d -l %d' % (region.minx, region.miny, region.width, region.height, region.level)
+    print "Searching for tiles at %s: " % region.name(),
+    args = [os.path.join(options.vw_bin_path,'tiles4region'), platefile_url] + args.split(' ')
+    while True:
+        try:
+            output = subprocess.check_output( args )
+            break
+        except subprocess.CalledProcessError, e:
+            print "%s RETRYING" % str(e)
+            continue
+    response = json.loads(output)
+    if response['ok']:
+        tiles = [ Tile(**t) for t in response['result'] ]
+    else:
+        if response['error'] == "TOO DEEP":
+            raise PlateDepthExceededException()
+        else:
+            raise PlateException(response['error'])
+    print "FOUND %d" % len(tiles)
+    return tiles
+
+def create_lod(minpix, maxpix, factory):
+    lod = factory.CreateLod()
+    lod.set_minlodpixels(minpix)
+    lod.set_maxlodpixels(maxpix)
+    return lod
+
+def create_latlonalt_square(north, south, west, east,factory):
+    box = factory.CreateLatLonAltBox()
+    box.set_south(south)
+    box.set_north(north)
+    box.set_west(west)
+    box.set_east(east)
+    return box
+    
+    
+def overlay_for_tile(tile, factory):
+    goverlay = factory.CreateGroundOverlay()
+    region = TileRegion(tile.level, BBox(tile.col, tile.row, 1, 1)).kml_region()
+    goverlay.set_region(region)
+    goverlay.set_latlonbox(tile.latlonbox())
+    goverlay.set_draworder(tile.level * DEFAULT_DRAW_ORDER_FACTOR) 
+
+    url = urlparse.urljoin( options.baseurl, '/'.join( str(t) for t in (tile.level, tile.col, tile.row) ) + "."+tile.filetype )
+    icon = factory.CreateIcon()
+    icon.set_href( str(url) )
+    goverlay.set_icon( icon )
+
+    return goverlay
+
+def make_netlink(url, region, factory, name=None):
+    netlink = factory.CreateNetworkLink()
+    if region:
+        netlink.set_region(region.kml_region())
+    link = factory.CreateLink()
+    link.set_href(url)
+    link.set_viewrefreshmode( kmldom.VIEWREFRESHMODE_ONREGION )
+    netlink.set_link(link)
+    if name:
+        netlink.set_name(name)
+    return netlink
+
+def draw_level(levelno, plate, output_dir, prior_hit_regions, factory):
+    level = PlateLevel(levelno)
+    netlinks = []
+    hit_regions = []
+
+    region_queue = Queue.Queue()
+    output_queue = Queue.Queue()
+    die_event = threading.Event()
+
+    print "Launching %d workers." % options.workers
+    workers = []
+    for i in range(options.workers):
+        p = threading.Thread(target=draw_region_worker, args=(die_event, region_queue, output_queue, plate, output_dir, factory))
+        workers.append(p)
+        p.start()
+
+    rcount = 0
+    for region in level.regionate(restrict_to_regions=prior_hit_regions):
+        try:
+            region_queue.put(region)
+            rcount += 1
+        except PlateDepthExceededException:
+            print "Hit bottom!"
+            break
+    print "Searching %d regions at level %d" % (rcount, levelno)
+    print "Waiting for join..."
+    region_queue.join()
+    print "Joined!"
+
+    die_event.set()
+
+
+    while True:
+        try:
+            time.sleep(0.1)
+            region = output_queue.get(False)
+            netlink = make_netlink(os.path.basename(region.kmz_filename), region, factory, name=region.name())
+            netlinks.append(netlink)
+            hit_regions.append(region)
+            output_queue.task_done()
+        except Queue.Empty:
+            break
+
+    # clear the referenced list and replace contents with new hit_regions
+    del prior_hit_regions[:]
+    prior_hit_regions += hit_regions
+
+    print "Tiles in %d regions at level %d" % (len(netlinks), levelno)
+
+    if len(netlinks) == 0:
+        return None
+    else:
+        outfilename = os.path.join(output_dir, "%02d"%level.level+".kml")
+        with open(outfilename, 'w') as outfile:
+            folder = factory.CreateFolder()
+            folder.set_name("%02d" % level.level)
+            for netlink in netlinks:
+                folder.add_feature(netlink)
+            kml = factory.CreateKml()
+            kml.set_feature(folder)
+            outfile.write( kmldom.SerializePretty( kml ) )
+
+        #return make_netlink(outfilename, level.region, factory, name="%02d"%level.level)
+        return make_netlink(os.path.basename(outfilename), None, factory, name="%02d"%level.level)
+
+
+def draw_region(region, plate, output_dir, factory):
+    """
+    Pull a TileRegion from the region_queue.
+    Render the TileRegion to KML and write it to disk.
+    Create a libkml NetworkLink object for the file and put it on the netlink_queue.
+    """
+
+    goverlays = []
+
+    tiles = search_tiles_by_region(plate, region)
+    if len(tiles) == 0:
+        return None
+    #if len(tiles) > options.max_features:  # TODO: Implement (or remove) max features / netlinks
+
+    t = tiles[0]
+    region.tile_degree_size = math.sqrt(t.degree_width * t.degree_height) # this is actually consistent for the whole level.
+    for t in tiles:
+        goverlay = t.kml_overlay(factory)
+        goverlays.append(goverlay)
+
+        region.latlon_bbox.expand(t.west,t.south)
+        region.latlon_bbox.expand(t.east,t.north)
+
+    folder = factory.CreateFolder()
+    for goverlay in goverlays:
+        folder.add_feature(goverlay)
+    kml = factory.CreateKml()
+    kml.set_feature(folder)
+    kmlstr = kmldom.SerializePretty(kml)
+    kmzfile = zipfile.ZipFile(os.path.join(output_dir, region.kmz_filename), 'w')
+    kmzfile.writestr('doc.kml', kmlstr)
+    kmzfile.close()
+
+    return region
+
+def draw_region_worker(die_event, region_queue, output_queue, plate, output_dir, factory):
+    """
+    Loop infinitely and try to draw regions.
+    """
+    while True:
+        if die_event.is_set():
+            break
+        try:
+            region = region_queue.get(True, 0.1)
+        except Queue.Empty:
+            #print "Region queue empty.  Retrying"
+            continue
+        try:
+            result = draw_region(region, plate, output_dir, factory)
+            if result:
+                output_queue.put(result)
+        finally:
+            time.sleep(0.01)
+            region_queue.task_done()
+
+def draw_plate(platefile_url, output_dir):
+    if os.path.exists(output_dir):
+        print "Output directory already exists: %s" % output_dir
+        print "Replace? (y/n)",
+        answer = raw_input()
+        if answer.lower() != 'y':
+            exit(0)
+    else:
+        print "Creating %s" % output_dir
+        os.makedirs(output_dir)
+
+    global factory
+    factory = kmldom.KmlFactory.GetFactory()
+    level = 0
+    keep_drilling = True
+    netlinks = []
+    hit_regions = []
+    folder = factory.CreateFolder()
+    kml = factory.CreateKml()
+    if options.planet:
+        kml.set_hint("target=%s" % options.planet)
+    kml.set_feature(folder)
+    while keep_drilling and level <= options.max_levels:
+        print "Drawing level %d..." % level
+        netlink = draw_level(level, platefile_url, output_dir, hit_regions, factory)
+        keep_drilling = bool(netlink)
+        if netlink: netlinks.append(netlink)
+
+        for netlink in netlinks:
+            folder.add_feature(netlink)
+        print "Writing root.kml"
+        with open(os.path.join(output_dir, 'root.kml'), 'w') as outfile:
+            outfile.write(kmldom.SerializePretty(kml))
+
+        level += 1
+
+    print "Done."
+    sys.exit(0)
+
+        
+global options
+def main():
+    usage = "%s <platefile> <output_dir>" % sys.argv[0]
+    parser = optparse.OptionParser(usage=usage)
+    # TODO: Implement max_features
+    #parser.add_option('--max-features', dest='max_features', help="Maximum number of features to stuff into one kmz file.", default=DEFAULT_MAX_KMZ_FEATURES)
+    parser.add_option('--vw-bin', dest="vw_bin_path", help="Location of VW bin files", default=DEFAULT_VW_BIN_PATH)
+    parser.add_option('--baseurl', dest='baseurl', help="mod_plate base URL", default="http://example.tld/path/99999")
+    parser.add_option('-r','--regionation-offset', dest='regionation_offset', default=DEFAULT_REGIONATION_OFFSET)
+    parser.add_option('-l','--max-level', dest='max_levels', type='int', default=9999, help="Stop drawing after this level. **It is desirable to speficy this, even if you're going to max resolution, because we use it to set the LOD for the last level of the pyramid.**")
+    parser.add_option('--planet', dest='planet', help="Tell GE to load this in a particular planet mode (Earth, Moon, Mars)", default="mars")
+    parser.add_option('--workers', '-w', dest='workers', type='int', help="Number of worker subprocesses to spawn", default=DEFAULT_WORKERS)
+    #parser.add_option('--resume', dest='resume', action="store_true", default=False, help="Don't overwrite KMZ files if they already exist.")
+    global options
+    (options, args) = parser.parse_args()
+    if len(args) != 2:
+        parser.print_help()
+        sys.exit(1)  
+    (platefile_url, output_dir) = args
+    draw_plate(platefile_url, output_dir)
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/src/vw/Plate/tiles4region.cc
+++ b/src/vw/Plate/tiles4region.cc
@@ -1,0 +1,124 @@
+// __BEGIN_LICENSE__
+// Copyright (C) 2006-2010 United States Government as represented by
+// the Administrator of the National Aeronautics and Space Administration.
+// All Rights Reserved.
+// __END_LICENSE__
+
+
+#include <vw/Plate/PlateFile.h>
+#include <vw/Plate/TileManipulation.h>
+#include <vw/Plate/PlateManager.h>
+#include <vw/Cartography/GeoReference.h>
+using namespace vw;
+using namespace vw::platefile;
+using namespace vw::cartography;
+
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
+// #include <boost/foreach.hpp>
+
+struct Options {
+    std::string plate_url;
+    uint64 minx, miny, width, height, level;
+};
+
+void handle_arguments(int argc, char* argv[], Options& opt) {
+    po::options_description general_options("Get the tiles from a platefile at a particular level and region");
+    general_options.add_options()
+        ("level,l", po::value(&opt.level), "Level of the plate to search at")
+        //("transaction,t")
+        ("help,h", "Get help");
+
+    po::options_description hidden_options("");
+    hidden_options.add_options()
+      ("plate_url", po::value(&opt.plate_url), "")
+      ("minx", po::value(&opt.minx), "")
+      ("miny", po::value(&opt.miny), "")
+      ("width", po::value(&opt.width), "")
+      ("height", po::value(&opt.height), "");
+
+    po::options_description options("");
+    options.add(general_options).add(hidden_options);       
+
+    po::positional_options_description p;
+    p.add("plate_url", 1);
+    p.add("minx", 1);
+    p.add("miny", 1);
+    p.add("width", 1);
+    p.add("height", 1);
+
+    po::variables_map vm;
+    try {
+      po::store( po::command_line_parser( argc, argv ).options(options).positional(p).run(), vm );
+      po::notify( vm );
+    } catch (po::error &e) {
+      vw_throw( ArgumentErr() << "Error parsing input:\n\t"
+                << e.what() << options );
+    }
+
+    std::ostringstream usage;
+    usage << "Usage: " << argv[0] << " <plate url> minx miny width height\n";
+    
+    if ( vm.count("help")  || 
+      ! vm.count("level") || ! vm.count("plate_url") ||
+      ! vm.count("minx") || ! vm.count("miny") || ! vm.count("width") || ! vm.count("height") 
+    ){
+        vw_throw( ArgumentErr() << usage.str() << general_options );
+    }
+}
+
+
+int main( int argc, char *argv[]) {
+    Options opt;
+    try {
+        handle_arguments( argc, argv, opt);
+    } catch (const Exception& e ) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
+
+    boost::shared_ptr<PlateFile> plate( new PlateFile(opt.plate_url) );
+    
+
+    if (opt.level >= plate->index_header().num_levels()) {
+        std::cout << "{\n";
+        std::cout << "  \"ok\": false,";
+        std::cout << "  \"error\": \"TOO DEEP\"\n";
+        std::cout << "}";
+        return 0;
+    } else {
+
+        PlateManager<vw::PixelGrayA<uint8> >* pm = 
+            PlateManager<vw::PixelGrayA<uint8> >::make( plate->index_header().type(), plate);
+        vw::cartography::GeoReference georef = pm->georeference(opt.level);
+
+        BBox2i region(opt.minx, opt.miny, opt.width, opt.height);
+        TransactionOrNeg id(-1);
+        std::list<TileHeader> tile_records;
+        tile_records = plate->search_by_region(opt.level,region,id,id,0,false);
+
+        printf("{ \"ok\": true,\n");
+        printf("\"result\": [\n");
+        std::list<TileHeader>::iterator i;
+        for (i=tile_records.begin(); i != tile_records.end(); i++) {
+            if (i != tile_records.begin()) { std::cout << ",\n"; }
+
+            const TileHeader& t = *i;
+
+            int tile_size = plate->default_tile_size();
+            Vector2 corner1 = georef.point_to_lonlat(georef.pixel_to_point( Vector2(t.col() * tile_size, t.row() * tile_size )));
+            Vector2 corner2 = georef.point_to_lonlat(georef.pixel_to_point( Vector2((t.col()+1) * tile_size, (t.row()+1) * tile_size )));
+            float west = corner1[0];
+            float east = corner2[0];
+            float north = corner1[1];
+            float south = corner2[1];
+
+            printf("{\"level\":%u,\"col\":%u,\"row\":%u,\"west\":%f, \"east\":%f, \"north\":%f, \"south\":%f, \"filetype\":\"%s\"}", 
+                t.level(), t.col(), t.row(), west, east, north, south, t.filetype().c_str() );
+        }
+        printf("\n]\n");
+        printf("}");
+
+        return 0;
+    }
+}


### PR DESCRIPTION
This is the python version of plate2kml.
To run, it requires libkml to be installed with python bindings, and it probably won't work with Python < 2.7.

It also depends on the included tiles4region.cc tool, which connects to a plate file to query which tiles exist for a given bounding box and outputs JSON that plate2kml.py can use to do its thing.  The plate Makefil.am has been updated so it will build this, but please verify that I've done everything necessary to make it play nice with the build system.   Does it need tests?

t.
