### PR TITLE
fix image test due to use Boost Filesytem V3

### DIFF
--- a/src/vw/Image/tests/TestImageResource.cxx
+++ b/src/vw/Image/tests/TestImageResource.cxx
@@ -247,7 +247,7 @@ TEST_F(TestStream, WriteResize) {
   //ASSERT_NO_THROW(r.write(src, box));
   r.write(src, box);
   ASSERT_NO_THROW(r.flush());
-  ASSERT_EQ(size(), fs::file_size(name));
+  ASSERT_EQ(size(), fs::file_size(static_cast<std::string>(name)));
 
   // reset the pointer for the rewrite
   ASSERT_NO_THROW(r.reset());
@@ -255,12 +255,12 @@ TEST_F(TestStream, WriteResize) {
   // repeat write to make sure it doesn't resize even bigger (it should overwrite old)
   ASSERT_NO_THROW(r.write(src, box));
   ASSERT_NO_THROW(r.flush());
-  ASSERT_EQ(size(), fs::file_size(name));
+  ASSERT_EQ(size(), fs::file_size(static_cast<std::string>(name)));
 
   // this should now append to the file
   ASSERT_NO_THROW(r.write(src, box));
   ASSERT_NO_THROW(r.flush());
-  ASSERT_EQ(2*size(), fs::file_size(name));
+  ASSERT_EQ(2*size(), fs::file_size(static_cast<std::string>(name)));
 }
 
 #if 0


### PR DESCRIPTION
It seems that Boost Filesystem V3 has added a separate path class, though Boost Filesystem V2 uses basic_string<> class template, and VW check uses UnlinkName (class UnlinkName : public std::string) for file path.

So in Boost Filesystem V2, VW can convert UnlinkName to file_size(const Path&), but can't convert UnlinkName to file_size(const path&) of Boost Filesystem V3.