### PR TITLE
Remove unused variables across VW.

### DIFF
--- a/src/vw/FileIO/DiskImageResourceJPEG.cc
+++ b/src/vw/FileIO/DiskImageResourceJPEG.cc
@@ -60,10 +60,6 @@ static void vw_jpeg_error_exit(j_common_ptr cinfo) {
 */
 class DiskImageResourceJPEG::vw_jpeg_decompress_context
 {
-  // The enclosing class. Need the pointer so we can access its member
-  // variables.
-  DiskImageResourceJPEG *outer;
-
   jpeg_error_mgr jerr;
 
 public:
@@ -72,8 +68,7 @@ public:
   JSAMPARRAY scanline;
   int cstride;
 
-  vw_jpeg_decompress_context(DiskImageResourceJPEG *outer) : outer(outer)
-  {
+  vw_jpeg_decompress_context(DiskImageResourceJPEG *outer) {
     current_line = -1;
 
     // Set the position of the input stream at zero. Create a new decompress

--- a/src/vw/FileIO/DiskImageResourcePDS.h
+++ b/src/vw/FileIO/DiskImageResourcePDS.h
@@ -142,7 +142,6 @@ namespace vw {
     PixelFormatEnum planes_to_pixel_format(int32 planes) const;
     std::map<std::string, std::string> m_header_entries;
     int m_image_data_offset;
-    int m_native_num_planes;
     bool m_invalid_as_alpha;
     bool m_file_is_msb_first;
     std::string m_pds_data_filename;

--- a/src/vw/Stereo/SGM.cc
+++ b/src/vw/Stereo/SGM.cc
@@ -1283,12 +1283,13 @@ SemiGlobalMatcher::create_disparity_view() {
   ImageView<int> cost_second     (m_num_output_cols, m_num_output_rows);
   ImageView<int> cost_ratio      (m_num_output_cols, m_num_output_rows);
   ImageView<int> best_costs      (m_num_output_cols, m_num_output_rows);
-  ImageView<int> worst_costs     (m_num_output_cols, m_num_output_rows);*/
+  ImageView<int> worst_costs     (m_num_output_cols, m_num_output_rows);
+  double mean;
+  AccumCostType best, second;
+  int count = 0, worst=0;
+  */
   
   DisparityType dx, dy;
-  AccumCostType best, second;
-  double mean;
-  int count = 0, worst=0;
   int min_index=0;
   std::vector<AccumCostType> accum_buffer;
   for ( int j = 0; j < m_num_output_rows; j++ ) {


### PR DESCRIPTION
Clang was complaining about the following variables.

The stuff in FileIO are just plain not used.

The SGM unused variables are still used in debug code so I just moved them closer to where the
comment out thing is.