### PR TITLE
Fix homepage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ One or more of:
 - Subscription required; Send an empty email message with the subject 'subscribe' (without the quotes) to [vision-workbench-request@lists.nasa.gov][listr].
 - Send your messages to [vision-workbench@lists.nasa.gov][list].
 
-[home]: http://ti.arc.nasa.gov/tech/asr/intelligent-robotics/nasa-vision-workbench/
+[home]: https://ti.arc.nasa.gov/tech/asr/groups/intelligent-robotics/nasa-vision-workbench/
 [repo]: http://github.com/visionworkbench/visionworkbench
 [bugs]: http://github.com/visionworkbench/visionworkbench/issues
 [list]: mailto:vision-workbench@lists.nasa.gov


### PR DESCRIPTION
Problem: Existing link it broken, shows 404 on nasa website.

Solution: Change link